### PR TITLE
Fix SIGINT handling for thread process

### DIFF
--- a/gdbserver.c
+++ b/gdbserver.c
@@ -49,7 +49,7 @@ bool attach = false;
 
 void sigint_pid()
 {
-  kill(-threads.t[0].pid, SIGINT);
+  kill(threads.t[0].pid, SIGINT);
 }
 
 bool is_clone_event(int status)


### PR DESCRIPTION
It's possible this "-" was added by mistake. To allow the SIGINT to actually be delivered to the correct PID remove it.